### PR TITLE
handle incomplete read

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,16 @@ FROM python:3.7.4-buster
 
 ENV PROJECT_FOLDER=/opt/sciencebeam-trainer-delft
 
+ENV VENV=${PROJECT_HOME}/venv
+RUN python3 -m venv ${VENV}
+ENV PYTHONUSERBASE=${VENV} PATH=${VENV}/bin:$PATH
+
 WORKDIR ${PROJECT_FOLDER}
 
 ENV PATH=/root/.local/bin:${PATH}
 
 COPY requirements.txt ./
-RUN pip install --user -r requirements.txt
+RUN pip install -r requirements.txt
 
 ARG install_dev
 COPY requirements.dev.txt ./

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,20 @@ VENV = venv
 PIP = $(VENV)/bin/pip
 PYTHON = $(VENV)/bin/python
 
-RUN = $(DOCKER_COMPOSE) run --rm datacapsule-crossref
+USER_ID = $(shell id -u)
+
+RUN = $(DOCKER_COMPOSE) run --user $(USER_ID) --rm datacapsule-crossref
 DEV_RUN = $(DOCKER_COMPOSE) run --rm datacapsule-crossref-dev
 
+
+CROSSREF_WORKS_API_URL = https://api.crossref.org/works
+ELIFE_CROSSREF_WORKS_API_URL = https://api.crossref.org/prefixes/10.7554/works
+
+COMPRESSION = lzma
+MAX_RETRIES =
+EMAIL =
+
+OUTPUT_SUFFIX =
 
 ARGS =
 
@@ -84,6 +95,22 @@ lint: \
 test: \
 	lint \
 	pytest
+
+
+download-works:
+	$(RUN) python -m datacapsule_crossref.download_works \
+		--base-url=$(CROSSREF_WORKS_API_URL) \
+		--compression=$(COMPRESSION) \
+		--email=$(EMAIL) \
+		--output-file=/data/crossref-works$(OUTPUT_SUFFIX).zip \
+		$(ARGS)
+
+
+download-works-elife:
+	$(MAKE) \
+		CROSSREF_WORKS_API_URL=$(ELIFE_CROSSREF_WORKS_API_URL) \
+		OUTPUT_SUFFIX=-elife \
+		download-works
 
 
 ci-build-and-test:

--- a/datacapsule_crossref/download_works.py
+++ b/datacapsule_crossref/download_works.py
@@ -24,8 +24,7 @@ LZMA = "lzma"
 DEFAULT_CROSSREF_API_URL = 'http://api.crossref.org/works'
 
 
-def get_logger():
-    return logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 def get_args_parser():
@@ -82,8 +81,6 @@ def add_url_parameters(base_url, parameters):
 
 
 def iter_page_responses(base_url, max_retries, start_cursor='*'):
-    logger = get_logger()
-
     next_cursor_pattern = re.compile(r'"next-cursor":"([^"]+?)"')
 
     with FuturesSession(max_workers=10) as session:
@@ -111,7 +108,7 @@ def iter_page_responses(base_url, max_retries, start_cursor='*'):
             first_chars = first_bytes.decode()
             m = next_cursor_pattern.search(first_chars)
             next_cursor = m.group(1).replace('\\/', '/') if m else None
-            logger.debug('next_cursor: %s', next_cursor)
+            LOGGER.debug('next_cursor: %s', next_cursor)
             if next_cursor == previous_cursor:
                 next_cursor = None
 
@@ -121,7 +118,7 @@ def iter_page_responses(base_url, max_retries, start_cursor='*'):
                 future_response = request_page(next_cursor)
                 previous_cursor = next_cursor
             else:
-                logger.info('no next_cursor found, end reached?')
+                LOGGER.info('no next_cursor found, end reached?')
                 future_response = None
 
             remaining_bytes = raw.read()
@@ -130,8 +127,6 @@ def iter_page_responses(base_url, max_retries, start_cursor='*'):
 
 
 def save_page_responses(base_url, zip_filename, max_retries, items_per_page, compression):
-    logger = get_logger()
-
     state_filename = zip_filename + '.meta'
     page_filename_pattern = '{}-page-{{}}-offset-{{}}.json'.format(
         os.path.splitext(os.path.basename(zip_filename))[0]
@@ -153,7 +148,7 @@ def save_page_responses(base_url, zip_filename, max_retries, items_per_page, com
                     previous_state['items_per_page']
                 ))
 
-    logger.info('start cursor: %s (offset %s, total: %s)',
+    LOGGER.info('start cursor: %s (offset %s, total: %s)',
                 start_cursor, offset, total_results)
 
     total_results_pattern = re.compile(r'"total-results":(\d+)\D')
@@ -169,7 +164,7 @@ def save_page_responses(base_url, zip_filename, max_retries, items_per_page, com
             )
 
             for next_cursor, page_response in page_responses:
-                logger.debug('response: %s (%s)', len(
+                LOGGER.debug('response: %s (%s)', len(
                     page_response), next_cursor)
 
                 if total_results is None:

--- a/datacapsule_crossref/download_works.py
+++ b/datacapsule_crossref/download_works.py
@@ -142,7 +142,6 @@ class PageResponseIterator:
         raw.decode_content = True
         first_bytes = raw.read(1000)
         first_chars = first_bytes.decode()
-        LOGGER.debug('first_chars: %s', first_chars)
         m = self._next_cursor_pattern.search(first_chars)
         next_cursor = m.group(1).replace('\\/', '/') if m else None
         LOGGER.debug('next_cursor: %s', next_cursor)

--- a/datacapsule_crossref/download_works.py
+++ b/datacapsule_crossref/download_works.py
@@ -8,7 +8,6 @@ import json
 import zipfile
 from zipfile import ZipFile
 from asyncio import Future
-from typing import Dict
 
 from urllib3.exceptions import ProtocolError
 

--- a/datacapsule_crossref/download_works.py
+++ b/datacapsule_crossref/download_works.py
@@ -80,9 +80,50 @@ def add_url_parameters(base_url, parameters):
     )
 
 
-def iter_page_responses(base_url, max_retries, start_cursor='*'):
-    next_cursor_pattern = re.compile(r'"next-cursor":"([^"]+?)"')
+def iter_page_responses_from_session(
+        session: FuturesSession,
+        base_url: str,
+        start_cursor: str = '*'):
 
+    def request_page(cursor):
+        url = add_url_parameters(base_url, {'cursor': cursor})
+        return session.get(url, stream=True)
+
+    next_cursor_pattern = re.compile(r'"next-cursor":\s*"([^"]+?)"')
+    future_response = request_page(start_cursor)
+    previous_cursor = start_cursor
+    while future_response:
+        response = future_response.result()
+        response.raise_for_status()
+
+        # try to find the next cursor in the first response characters
+        # we don't need to wait until the whole response has been received
+        raw = response.raw
+        raw.decode_content = True
+        first_bytes = raw.read(1000)
+        first_chars = first_bytes.decode()
+        LOGGER.debug('first_chars: %s', first_chars)
+        m = next_cursor_pattern.search(first_chars)
+        next_cursor = m.group(1).replace('\\/', '/') if m else None
+        LOGGER.debug('next_cursor: %s', next_cursor)
+        if next_cursor == previous_cursor:
+            next_cursor = None
+
+        if next_cursor:
+            # request the next page as soon as possible,
+            # we will read the result in the next iteration
+            future_response = request_page(next_cursor)
+            previous_cursor = next_cursor
+        else:
+            LOGGER.info('no next_cursor found, end reached?')
+            future_response = None
+
+        remaining_bytes = raw.read()
+        content = first_bytes + remaining_bytes
+        yield next_cursor, content
+
+
+def iter_page_responses(base_url, max_retries, start_cursor='*'):
     with FuturesSession(max_workers=10) as session:
         configure_session_retry(
             session=session,
@@ -90,40 +131,11 @@ def iter_page_responses(base_url, max_retries, start_cursor='*'):
             status_forcelist=[500, 502, 503, 504]
         )
 
-        def request_page(cursor):
-            url = add_url_parameters(base_url, {'cursor': cursor})
-            return session.get(url, stream=True)
-
-        future_response = request_page(start_cursor)
-        previous_cursor = start_cursor
-        while future_response:
-            response = future_response.result()
-            response.raise_for_status()
-
-            # try to find the next cursor in the first response characters
-            # we don't need to wait until the whole response has been received
-            raw = response.raw
-            raw.decode_content = True
-            first_bytes = raw.read(1000)
-            first_chars = first_bytes.decode()
-            m = next_cursor_pattern.search(first_chars)
-            next_cursor = m.group(1).replace('\\/', '/') if m else None
-            LOGGER.debug('next_cursor: %s', next_cursor)
-            if next_cursor == previous_cursor:
-                next_cursor = None
-
-            if next_cursor:
-                # request the next page as soon as possible,
-                # we will read the result in the next iteration
-                future_response = request_page(next_cursor)
-                previous_cursor = next_cursor
-            else:
-                LOGGER.info('no next_cursor found, end reached?')
-                future_response = None
-
-            remaining_bytes = raw.read()
-            content = first_bytes + remaining_bytes
-            yield next_cursor, content
+        yield from iter_page_responses_from_session(
+            session=session,
+            base_url=base_url,
+            start_cursor=start_cursor
+        )
 
 
 def save_page_responses(base_url, zip_filename, max_retries, items_per_page, compression):

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,6 +1,10 @@
 version: '3'
 
 services:
+  datacapsule-crossref:
+    volumes:
+      - ./data:/data
+
   datacapsule-crossref-jupyter:
     volumes:
       - .:/home/jovyan/datacapsule-crossref-jupyter

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests==2.22.0
 requests-futures==1.0.0
 six==1.12.0
 tqdm==4.34.0
+waiter==1.0

--- a/tests/download_works_test.py
+++ b/tests/download_works_test.py
@@ -1,6 +1,74 @@
+import logging
+import json
+from unittest.mock import MagicMock
+from asyncio import Future
+from io import BytesIO
+from functools import wraps
+
+import pytest
+
 from datacapsule_crossref.download_works import (
-    add_url_parameters
+    add_url_parameters,
+    iter_page_responses_from_session
 )
+
+
+LOGGER = logging.getLogger(__name__)
+
+TEST_CROSSREF_API_URL = 'test://crossref/api/works'
+
+CURSOR_1 = 'cursor1'
+CURSOR_2 = 'cursor2'
+
+
+@pytest.fixture(name='session_mock')
+def _session_mock():
+    mock = MagicMock(name='session')
+    return mock
+
+
+def _resolved_future(result) -> Future:
+    future = Future()
+    future.set_result(result)
+    return future
+
+
+def _mock_session_response(data: bytes):
+    data_stream = BytesIO(data)
+    mock = MagicMock(name='session_response')
+    mock.raw.read = data_stream.read
+    return mock
+
+
+def _mock_session_get(url_to_response_map: dict):
+    @wraps(url_to_response_map.__getitem__)
+    def wrapper(url, **_):
+        response = url_to_response_map[url]
+        if isinstance(response, bytes):
+            return _resolved_future(_mock_session_response(response))
+        if not isinstance(response, Future):
+            return _resolved_future(response)
+        return response
+    return wrapper
+
+
+def _mock_response_data(status: str = 'ok', next_cursor: str = None):
+    return json.dumps({
+        'status': status,
+        'message': {
+            'next-cursor': next_cursor
+        }
+    }).encode('utf-8')
+
+
+def _url_with_cursor(base_url: str, cursor: str):
+    return '%s?cursor=%s' % (base_url, cursor)
+
+
+def _page_responses_from_session(*args, **kwargs):
+    result = list(iter_page_responses_from_session(*args, **kwargs))
+    LOGGER.debug('result: %s', result)
+    return result
 
 
 class TestAddUrlParameters(object):
@@ -39,3 +107,36 @@ class TestAddUrlParameters(object):
             add_url_parameters('http://somewhere', [('value', '?& ')]) ==
             r'http://somewhere?value=%3F%26+'
         )
+
+
+class TestIterPageResponsesFromSession:
+    def test_should_request_single_page(
+            self, session_mock: MagicMock):
+        response_data = _mock_response_data()
+        session_mock.get = _mock_session_get({
+            _url_with_cursor(TEST_CROSSREF_API_URL, CURSOR_1): response_data
+        })
+        assert list(iter_page_responses_from_session(
+            session=session_mock,
+            base_url=TEST_CROSSREF_API_URL,
+            start_cursor=CURSOR_1
+        )) == [
+            (None, response_data)
+        ]
+
+    def test_should_request_multiple_pages(
+            self, session_mock: MagicMock):
+        response_data_1 = _mock_response_data(next_cursor=CURSOR_2)
+        response_data_2 = _mock_response_data()
+        session_mock.get = _mock_session_get({
+            _url_with_cursor(TEST_CROSSREF_API_URL, CURSOR_1): response_data_1,
+            _url_with_cursor(TEST_CROSSREF_API_URL, CURSOR_2): response_data_2
+        })
+        assert _page_responses_from_session(
+            session=session_mock,
+            base_url=TEST_CROSSREF_API_URL,
+            start_cursor=CURSOR_1
+        ) == [
+            (CURSOR_2, response_data_1),
+            (None, response_data_2)
+        ]

--- a/tests/download_works_test.py
+++ b/tests/download_works_test.py
@@ -4,12 +4,13 @@ from unittest.mock import MagicMock
 from asyncio import Future
 from io import BytesIO
 from functools import wraps
+from urllib3.exceptions import ProtocolError
 
 import pytest
 
 from datacapsule_crossref.download_works import (
     add_url_parameters,
-    iter_page_responses_from_session
+    PageResponseIterator
 )
 
 
@@ -40,10 +41,38 @@ def _mock_session_response(data: bytes):
     return mock
 
 
+def _sequential_side_effects(side_effects: list):
+    iterator = iter(side_effects)
+
+    def side_effect_wrapper(*args, **kwargs):
+        side_effect = next(iterator)
+        if isinstance(side_effect, Exception):
+            raise side_effect
+        if isinstance(side_effect, MagicMock):
+            return side_effect
+        if callable(side_effect):
+            return side_effect(*args, **kwargs)
+        return side_effect
+    return side_effect_wrapper
+
+
+def _mock_incomplete_read_session_response(data: bytes):
+    data_stream = BytesIO(data)
+    mock = MagicMock(name='session_response')
+    mock.raw.read.side_effect = _sequential_side_effects([
+        data_stream.read,
+        ProtocolError('IncompleteRead')
+    ])
+    return mock
+
+
 def _mock_session_get(url_to_response_map: dict):
     @wraps(url_to_response_map.__getitem__)
-    def wrapper(url, **_):
+    def wrapper(url, **kwargs):
         response = url_to_response_map[url]
+        if callable(response):
+            response = response(url, **kwargs)
+            LOGGER.debug('callable response: %s', response)
         if isinstance(response, bytes):
             return _resolved_future(_mock_session_response(response))
         if not isinstance(response, Future):
@@ -66,8 +95,10 @@ def _url_with_cursor(base_url: str, cursor: str):
 
 
 def _page_responses_from_session(*args, **kwargs):
-    result = list(iter_page_responses_from_session(*args, **kwargs))
+    iterator = PageResponseIterator(*args, **kwargs)
+    result = list(iterator)
     LOGGER.debug('result: %s', result)
+    assert not iterator.get_cache_size()
     return result
 
 
@@ -109,18 +140,18 @@ class TestAddUrlParameters(object):
         )
 
 
-class TestIterPageResponsesFromSession:
+class TestPageResponseIterator:
     def test_should_request_single_page(
             self, session_mock: MagicMock):
         response_data = _mock_response_data()
         session_mock.get = _mock_session_get({
             _url_with_cursor(TEST_CROSSREF_API_URL, CURSOR_1): response_data
         })
-        assert list(iter_page_responses_from_session(
+        assert _page_responses_from_session(
             session=session_mock,
             base_url=TEST_CROSSREF_API_URL,
             start_cursor=CURSOR_1
-        )) == [
+        ) == [
             (None, response_data)
         ]
 
@@ -130,6 +161,27 @@ class TestIterPageResponsesFromSession:
         response_data_2 = _mock_response_data()
         session_mock.get = _mock_session_get({
             _url_with_cursor(TEST_CROSSREF_API_URL, CURSOR_1): response_data_1,
+            _url_with_cursor(TEST_CROSSREF_API_URL, CURSOR_2): response_data_2
+        })
+        assert _page_responses_from_session(
+            session=session_mock,
+            base_url=TEST_CROSSREF_API_URL,
+            start_cursor=CURSOR_1
+        ) == [
+            (CURSOR_2, response_data_1),
+            (None, response_data_2)
+        ]
+
+    def test_should_retry_on_incomplete_read(
+            self, session_mock: MagicMock):
+        response_data_1 = _mock_response_data(next_cursor=CURSOR_2)
+        response_1_incomplete = _mock_incomplete_read_session_response(response_data_1)
+        response_data_2 = _mock_response_data()
+        session_mock.get = _mock_session_get({
+            _url_with_cursor(TEST_CROSSREF_API_URL, CURSOR_1): _sequential_side_effects([
+                response_1_incomplete,
+                response_data_1
+            ]),
             _url_with_cursor(TEST_CROSSREF_API_URL, CURSOR_2): response_data_2
         })
         assert _page_responses_from_session(


### PR DESCRIPTION
handle errors like these:

```bash
DEBUG:urllib3.connectionpool:https://api.crossref.org:443 "GET /works?rows=1000&mailto=email&cursor=AoJ9tO65ousCPwRodHRwOi8vZHguZG9pLm9yZy8xMC4xMDAyL2pjYi4yMjkzNQ%3D%3D HTTP/1.1" 200 10378424
Traceback (most recent call last):                                 
  File "/path/to/datacapsule-crossref/venv/lib/python3.5/site-packages/urllib3/response.py", line 302, in _error_catcher
    yield
  File "/path/to/datacapsule-crossref/venv/lib/python3.5/site-packages/urllib3/response.py", line 380, in read
    data = self._fp.read()
  File "/usr/lib/python3.5/http/client.py", line 461, in read
    s = self._safe_read(self.length)
  File "/usr/lib/python3.5/http/client.py", line 609, in _safe_read
    raise IncompleteRead(b''.join(s), amt)
http.client.IncompleteRead: IncompleteRead(980504 bytes read, 11871570 more expected)
```