### PR TITLE
make figshare part prefix configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ MAX_RETRIES =
 EMAIL =
 
 OUTPUT_SUFFIX =
+FIGSHARE_PART_PREFIX = /tmp/part_
 
 ARGS =
 
@@ -190,7 +191,8 @@ generate-reference-stats-elife:
 
 
 figshare-upload-works:
-	$(RUN) figshare-upload.sh /data/crossref-works$(OUTPUT_SUFFIX).zip
+	$(RUN) figshare-upload.sh \
+		/data/crossref-works$(OUTPUT_SUFFIX).zip "" "$(FIGSHARE_PART_PREFIX)"
 
 
 figshare-upload-works-elife:
@@ -198,7 +200,8 @@ figshare-upload-works-elife:
 
 
 figshare-upload-citations:
-	$(RUN) figshare-upload.sh /data/crossref-works$(OUTPUT_SUFFIX)-citations.tsv.gz
+	$(RUN) figshare-upload.sh \
+		/data/crossref-works$(OUTPUT_SUFFIX)-citations.tsv.gz "" "$(FIGSHARE_PART_PREFIX)"
 
 
 figshare-upload-citations-elife:

--- a/scripts/figshare-upload.sh
+++ b/scripts/figshare-upload.sh
@@ -26,10 +26,11 @@ fi
 ACCESS_TOKEN=$FIGSHARE_ACCESS_TOKEN
 
 FILE_PATH="$1"
-ITEM_ID=$2
+ITEM_ID=${2:-$FIGSHARE_ITEM_ID}
+PART_PREFIX="${3:-$FIGSHARE_PART_PREFIX}"
 
 if [ -z "$FILE_PATH" ]; then
-  echo "Usage: $0 <file path> [<item id>]"
+  echo "Usage: $0 <file path> [<item id>] [<part prefix>]"
   echo ''
   echo 'A new item will be created if item id is not provided.'
   echo ''
@@ -39,13 +40,18 @@ if [ -z "$FILE_PATH" ]; then
   exit 2
 fi
 
-# exit 0
-
 FILE_NAME=$(basename "$FILE_PATH")
 
-PART_PREFIX="$(dirname "$FILE_PATH")/part_"
+if [ -z "${PART_PREFIX}" ]; then
+  PART_PREFIX="$(dirname "$FILE_PATH")/part_"
+fi
 
 echo "PART_PREFIX=${PART_PREFIX}"
+
+if ls "${PART_PREFIX}"* 1> /dev/null 2>&1; then
+  echo "existing part files found, please review and remove them first (prefix: ${PART_PREFIX})"
+  exit 2
+fi
 
 # ####################################################################################
 


### PR DESCRIPTION
This allows one to use the `/tmp` partition instead.